### PR TITLE
add tcp tls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ gem install fluent-plugin-gelf
   host <remote GELF host>
   port <remote GELF port>
   protocol <tcp or udp (default)>
+	tls <true or false (default)>
+	tls_options <{} (default)> for options see https://github.com/graylog-labs/gelf-rb/blob/72916932b789f7a6768c3cdd6ab69a3c942dbcef/lib/gelf/transport/tcp_tls.rb#L7-L12
   [ fluent buffered output plugin configuration ]
 </match>
 ```

--- a/lib/fluent/plugin/out_gelf.rb
+++ b/lib/fluent/plugin/out_gelf.rb
@@ -13,6 +13,8 @@ module Fluent
     config_param :host, :string, :default => nil
     config_param :port, :integer, :default => 12201
     config_param :protocol, :string, :default => 'udp'
+    config_param :tls, :bool, :default => false
+    config_param :tls_options, :hash, :default => {}
 
     def initialize
       super
@@ -35,7 +37,15 @@ module Fluent
     def start
       super
 
-      @conn = GELF::Notifier.new(@host, @port, 'WAN', {:facility => 'fluentd', :protocol => @proto})
+      options = {:facility => 'fluentd', :protocol => @proto}
+
+      # add tls key (tls_options) only when tls = True
+      # see https://github.com/graylog-labs/gelf-rb/blob/72916932b789f7a6768c3cdd6ab69a3c942dbcef/lib/gelf/notifier.rb#L133-L140
+      if @tls then
+        options[:tls] = @tls_options
+      end
+
+      @conn = GELF::Notifier.new(@host, @port, 'WAN', options)
 
       # Errors are not coming from Ruby so we use direct mapping
       @conn.level_mapping = 'direct'


### PR DESCRIPTION
I added tls support for tcp protocol.

GELF had already tls support
see
https://github.com/graylog-labs/gelf-rb/blob/72916932b789f7a6768c3cdd6ab69a3c942dbcef/lib/gelf/notifier.rb#L133-L140

and for the tls_options
https://github.com/graylog-labs/gelf-rb/blob/72916932b789f7a6768c3cdd6ab69a3c942dbcef/lib/gelf/transport/tcp_tls.rb#L7-L12