### PR TITLE
Dissallow whitespace as valid short_message

### DIFF
--- a/lib/fluent/gelf_util.rb
+++ b/lib/fluent/gelf_util.rb
@@ -67,15 +67,15 @@ module Fluent
         end
       end
 
-      if !gelfentry.key?('short_message') or gelfentry['short_message'].to_s.empty? then
+      if !gelfentry.key?('short_message') or gelfentry['short_message'].to_s.blank? then
         # allow other non-empty fields to masquerade as the short_message if it is unset
-        if gelfentry.key?('_message') and !gelfentry['_message'].to_s.empty? then
+        if gelfentry.key?('_message') and !gelfentry['_message'].to_s.blank? then
           gelfentry['short_message'] = gelfentry.delete('_message')
-        elsif gelfentry.key?('_msg') and !gelfentry['_msg'].to_s.empty? then
+        elsif gelfentry.key?('_msg') and !gelfentry['_msg'].to_s.blank? then
           gelfentry['short_message'] = gelfentry.delete('_msg')
-        elsif gelfentry.key?('_log') and !gelfentry['_log'].to_s.empty? then
+        elsif gelfentry.key?('_log') and !gelfentry['_log'].to_s.blank? then
           gelfentry['short_message'] = gelfentry.delete('_log')
-        elsif gelfentry.key?('_record') and !gelfentry['_record'].to_s.empty? then
+        elsif gelfentry.key?('_record') and !gelfentry['_record'].to_s.blank? then
           gelfentry['short_message'] = gelfentry.delete('_record')
         else
           # we must have a short_message, so provide placeholder

--- a/lib/fluent/gelf_util.rb
+++ b/lib/fluent/gelf_util.rb
@@ -100,5 +100,9 @@ module Fluent
 
       gelfentry.to_json + ( conf.is_a?(Hash) and conf.key?(:record_separator) ? conf[:record_separator] : "\0" )
     end
+
+    def blank?
+      /\A[[:space:]]*\z/ === self
+    end
   end
 end


### PR DESCRIPTION
Graylog doesn't accept whitespace as valid short_message, so the plugin should behave the same way.

This is the GEFL validation function for reference: https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java#L230-L269