### PR TITLE
Improve empty short_message identification

### DIFF
--- a/lib/fluent/gelf_util.rb
+++ b/lib/fluent/gelf_util.rb
@@ -67,7 +67,7 @@ module Fluent
         end
       end
 
-      if !gelfentry.key?('short_message') or gelfentry['short_message'].to_s.empty? or !is_text(gelfentry['short_message'].bytes.to_a) then
+      if !gelfentry.key?('short_message') or gelfentry['short_message'].to_s.empty? or gelfentry['short_message'].to_s.strip.empty? then
         # allow other non-empty fields to masquerade as the short_message if it is unset
         if gelfentry.key?('_message') and !gelfentry['_message'].to_s.empty? then
           gelfentry['short_message'] = gelfentry.delete('_message')
@@ -88,16 +88,6 @@ module Fluent
       return gelfentry.delete_if{ |k,v| v.nil? }
 
     end
-
-    def is_text(bytes)
-        for c in bytes do
-            if c > 32 && c != 127 then
-                return true
-            end
-        end
-        return false
-    end
-
 
     def make_json(gelfentry,conf)
       gelfentry['version'] = '1.0'

--- a/lib/fluent/gelf_util.rb
+++ b/lib/fluent/gelf_util.rb
@@ -67,7 +67,7 @@ module Fluent
         end
       end
 
-      if !gelfentry.key?('short_message') or gelfentry['short_message'].to_s.empty? then
+      if !gelfentry.key?('short_message') or gelfentry['short_message'].to_s.empty? or !is_text(gelfentry['short_message'].bytes.to_a) then
         # allow other non-empty fields to masquerade as the short_message if it is unset
         if gelfentry.key?('_message') and !gelfentry['_message'].to_s.empty? then
           gelfentry['short_message'] = gelfentry.delete('_message')
@@ -88,6 +88,16 @@ module Fluent
       return gelfentry.delete_if{ |k,v| v.nil? }
 
     end
+
+    def is_text(bytes)
+        for c in bytes do
+            if c > 32 && c != 127 then
+                return true
+            end
+        end
+        return false
+    end
+
 
     def make_json(gelfentry,conf)
       gelfentry['version'] = '1.0'

--- a/lib/fluent/gelf_util.rb
+++ b/lib/fluent/gelf_util.rb
@@ -67,15 +67,15 @@ module Fluent
         end
       end
 
-      if !gelfentry.key?('short_message') or gelfentry['short_message'].to_s.empty? or gelfentry['short_message'].to_s.strip.empty? then
+      if !gelfentry.key?('short_message') or gelfentry['short_message'].to_s.strip.empty? then
         # allow other non-empty fields to masquerade as the short_message if it is unset
-        if gelfentry.key?('_message') and !gelfentry['_message'].to_s.empty? then
+        if gelfentry.key?('_message') and !gelfentry['_message'].to_s.strip.empty? then
           gelfentry['short_message'] = gelfentry.delete('_message')
-        elsif gelfentry.key?('_msg') and !gelfentry['_msg'].to_s.empty? then
+        elsif gelfentry.key?('_msg') and !gelfentry['_msg'].to_s.strip.empty? then
           gelfentry['short_message'] = gelfentry.delete('_msg')
-        elsif gelfentry.key?('_log') and !gelfentry['_log'].to_s.empty? then
+        elsif gelfentry.key?('_log') and !gelfentry['_log'].to_s.strip.empty? then
           gelfentry['short_message'] = gelfentry.delete('_log')
-        elsif gelfentry.key?('_record') and !gelfentry['_record'].to_s.empty? then
+        elsif gelfentry.key?('_record') and !gelfentry['_record'].to_s.strip.empty? then
           gelfentry['short_message'] = gelfentry.delete('_record')
         else
           # we must have a short_message, so provide placeholder

--- a/test/plugin/test_out_gelf.rb
+++ b/test/plugin/test_out_gelf.rb
@@ -31,23 +31,79 @@ class GELFOutputTest < Test::Unit::TestCase
   def test_format
     d = create_driver
     time = Time.now
-    d.emit({"message" => "gelf"}, time.to_i)
+    d.emit({'message' => 'gelf'}, time.to_i)
     d.expect_format({'_tag' => 'test', 'timestamp' => time.to_i, 'short_message' => 'gelf'}.to_msgpack)
+    d.run
+  end
+
+  def test_format_msg
+    d = create_driver
+    time = Time.now
+    d.emit({'_msg' => 'mymessage'}, time.to_i)
+    d.expect_format({'_tag' => 'test', 'timestamp' => time.to_i, 'short_message' => 'mymessage'}.to_msgpack)
+    d.run
+  end
+
+  def test_format_log
+    d = create_driver
+    time = Time.now
+    d.emit({'_log' => 'mylog'}, time.to_i)
+    d.expect_format({'_tag' => 'test', 'timestamp' => time.to_i, 'short_message' => 'mylog'}.to_msgpack)
+    d.run
+  end
+
+  def test_format_record
+    d = create_driver
+    time = Time.now
+    d.emit({'_record' => 'myrecord'}, time.to_i)
+    d.expect_format({'_tag' => 'test', 'timestamp' => time.to_i, 'short_message' => 'myrecord'}.to_msgpack)
     d.run
   end
 
   def test_empty_short_message
     d = create_driver
     time = Time.now
-    d.emit({"short_message" => "\n\r \n"}, time.to_i)
+    d.emit({'short_message' => "\n\r \n"}, time.to_i)
     d.expect_format({'_tag' => 'test', 'timestamp' => time.to_i, 'short_message' => '(no message)'}.to_msgpack)
+    d.run
+  end
+
+  def test_empty_message
+    d = create_driver
+    time = Time.now
+    d.emit({'_message' => "\n\r \n"}, time.to_i)
+    d.expect_format({'_tag' => 'test', 'timestamp' => time.to_i, '_message' => "\n\r \n", 'short_message' => '(no message)'}.to_msgpack)
+    d.run
+  end
+
+  def test_empty_msg
+    d = create_driver
+    time = Time.now
+    d.emit({'_msg' => "\n\r \n"}, time.to_i)
+    d.expect_format({'_tag' => 'test', 'timestamp' => time.to_i, '_msg' => "\n\r \n", 'short_message' => '(no message)'}.to_msgpack)
+    d.run
+  end
+
+  def test_empty_log
+    d = create_driver
+    time = Time.now
+    d.emit({'_log' => "\n\r \n"}, time.to_i)
+    d.expect_format({'_tag' => 'test', 'timestamp' => time.to_i, '_log' => "\n\r \n", 'short_message' => '(no message)'}.to_msgpack)
+    d.run
+  end
+
+  def test_empty_record
+    d = create_driver
+    time = Time.now
+    d.emit({'_record' => "\n\r \n"}, time.to_i)
+    d.expect_format({'_tag' => 'test', 'timestamp' => time.to_i, '_record' => "\n\r \n", 'short_message' => '(no message)'}.to_msgpack)
     d.run
   end
 
   def test_write
     d = create_driver
     time = Time.now
-    d.emit({"message" => "gelf"}, time.to_i)
+    d.emit({'message' => 'gelf'}, time.to_i)
     d.run
   end
 end

--- a/test/plugin/test_out_gelf.rb
+++ b/test/plugin/test_out_gelf.rb
@@ -36,6 +36,14 @@ class GELFOutputTest < Test::Unit::TestCase
     d.run
   end
 
+  def test_empty_short_message
+    d = create_driver
+    time = Time.now
+    d.emit({"short_message" => "\n \n"}, time.to_i)
+    d.expect_format({'_tag' => 'test', 'timestamp' => time.to_i, 'short_message' => '(no message)'}.to_msgpack)
+    d.run
+  end
+
   def test_write
     d = create_driver
     time = Time.now

--- a/test/plugin/test_out_gelf.rb
+++ b/test/plugin/test_out_gelf.rb
@@ -39,7 +39,7 @@ class GELFOutputTest < Test::Unit::TestCase
   def test_empty_short_message
     d = create_driver
     time = Time.now
-    d.emit({"short_message" => "\n \n"}, time.to_i)
+    d.emit({"short_message" => "\n\r \n"}, time.to_i)
     d.expect_format({'_tag' => 'test', 'timestamp' => time.to_i, 'short_message' => '(no message)'}.to_msgpack)
     d.run
   end


### PR DESCRIPTION
Handle cases where the `short_message` contains only control chars and spaces. This will lead to an error in the Graylog side.

## Related issues
- https://github.com/fluent/fluentd-kubernetes-daemonset/issues/243

## Reproduce
This can be reproduced by sending the following packet to a Graylog TCP or UDP input:
```
# TCP
echo -n '{ "version": "1.1", "host": "localhost", "short_message": "\n \n", "level": 5}' | nc -vw5 <IP> <PORT>
# UDP
echo -n '{ "version": "1.1", "host": "localhost", "short_message": "\n \n", "level": 5}' | nc -vuw5 <IP> <PORT>
```

Error output:
```
2019-08-12 09:04:05,522 ERROR   [DecodingProcessor] - Error processing message RawMessage{id=22de9723-bce0-11e9-a67f-f62dba2cc6c4, journalOffset=649416038, codec=gelf, payloadSize=1229, timestamp=2019-08-12T09:04:05.522Z, remoteAddress=/my_ip:26412} - {}
java.lang.IllegalArgumentException: GELF message <22de9723-bce0-11e9-a67f-f62dba2cc6c4> (received from <my_ip:26412>) has empty mandatory "short_message" field.
        at org.graylog2.inputs.codecs.GelfCodec.validateGELFMessage(GelfCodec.java:252) ~[graylog.jar:?]
        at org.graylog2.inputs.codecs.GelfCodec.decode(GelfCodec.java:134) ~[graylog.jar:?]
        at org.graylog2.shared.buffers.processors.DecodingProcessor.processMessage(DecodingProcessor.java:150) ~[graylog.jar:?]
        at org.graylog2.shared.buffers.processors.DecodingProcessor.onEvent(DecodingProcessor.java:91) [graylog.jar:?]
        at org.graylog2.shared.buffers.processors.ProcessBufferProcessor.onEvent(ProcessBufferProcessor.java:74) [graylog.jar:?]
        at org.graylog2.shared.buffers.processors.ProcessBufferProcessor.onEvent(ProcessBufferProcessor.java:42) [graylog.jar:?]
        at com.lmax.disruptor.WorkProcessor.run(WorkProcessor.java:143) [graylog.jar:?]
        at com.codahale.metrics.InstrumentedThreadFactory$InstrumentedRunnable.run(InstrumentedThreadFactory.java:66) [graylog.jar:?]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
```
## Environment
Currently running [this](https://github.com/fluent/fluentd-kubernetes-daemonset/tree/master/docker-image/v1.4/debian-graylog) image on k8s 1.14
