### PR TITLE
Duplicate frozen string value when force encoding in make_json

### DIFF
--- a/lib/fluent/gelf_util.rb
+++ b/lib/fluent/gelf_util.rb
@@ -94,7 +94,7 @@ module Fluent
 
       gelfentry.each_pair  do |k,v|
         if v.is_a?(String)
-          gelfentry[k] = v.force_encoding('UTF-8')
+          gelfentry[k] = v.dup.force_encoding('UTF-8')
         end
       end
 


### PR DESCRIPTION
When using the gelf formatter, like so:
```
<match **>
  @type stdout
  format gelf
</match>
```

We run encounter the following error:
```
#0 Error trying to serialize [original string]: can't modify frozen String
```

It appears that in the `make_json` function, the string values in `gelfentry` could potentially be a frozen string. This PR duplicates the string before calling `force_encoding`.